### PR TITLE
fix: 视频播放完时进度不为100%

### DIFF
--- a/enaeaHelperPlus.js
+++ b/enaeaHelperPlus.js
@@ -18,9 +18,17 @@
     let continuePlay = setInterval(continuePlayVideo, 3000);
     let continueChapter = setInterval(findAndStartChapter, 3000);
     let continueLesson = setInterval(clickNextPageButton, 3000);
+    let continueGoBack = setInterval(goBackToStart, 3000);
     let pageLoading = false;
     let currentPageComplete = true;
-    let playbackSpeed = 4; // Recommended speed: 2-4
+    let playbackSpeed = 10; // Recommended speed: 2-4
+
+    function goBackToStart() {
+        let video = document.getElementById("J_CC_videoPlayerDiv").childNodes[0];
+        if (video.currentTime > video.duration / 3) {
+            video.currentTime = 0;
+        }
+    }
 
     if (isContentsPage()) {
         continuePlayVideo();


### PR DESCRIPTION
播放器每1min向服务器发送一次有效的播放记录，造成高倍速播放时，未上报的记录丢失，由于上报记录仅包含停留时长，不包含确定的播放片段，因此可以考虑视频播放到50%时，回退视频进度。解决视频播放完，进度不为100%的问题